### PR TITLE
set the default order for processors to 10

### DIFF
--- a/manifests/processor.pp
+++ b/manifests/processor.pp
@@ -17,7 +17,7 @@
 #   }
 define otelcol::processor (
   Hash $config = {},
-  Integer[0,999] $order = 0,
+  Integer[0,999] $order = 10,
   Array[String[1]] $pipelines = [],
 ) {
   $real_order = 2000+$order


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
According to the [documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/README.md#recommended-processors) it would make sense to be able to declare processors that are always first.
Therefore I'd suggest to raise the default order value to 10. 

One could skip the order parameter in day-to-day operations and would still be able to have them in the right order.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
