### PR TITLE
Feature: support multiple configs

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -54,6 +54,7 @@ The following parameters are available in the `otelcol` class:
 * [`config_file_owner`](#-otelcol--config_file_owner)
 * [`config_file_group`](#-otelcol--config_file_group)
 * [`config_file_mode`](#-otelcol--config_file_mode)
+* [`configs`](#-otelcol--configs)
 * [`receivers`](#-otelcol--receivers)
 * [`processors`](#-otelcol--processors)
 * [`exporters`](#-otelcol--exporters)
@@ -149,6 +150,15 @@ Data type: `Stdlib::Filemode`
 mode of config_file
 
 Default value: `'0644'`
+
+##### <a name="-otelcol--configs"></a>`configs`
+
+Data type: `Array[String]`
+
+additional config files or resources to add. Since this can be environment variables, http urls or files
+you are required to ensure the existence of a file!
+
+Default value: `[]`
 
 ##### <a name="-otelcol--receivers"></a>`receivers`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,9 @@
 #   group of config_file
 # @param config_file_mode
 #   mode of config_file
+# @param configs
+#   additional config files or resources to add. Since this can be environment variables, http urls or files
+#   you are required to ensure the existence of a file!
 # @param receivers
 #   Hash for receivers config
 # @param processors
@@ -61,6 +64,7 @@ class otelcol (
   String  $config_file_owner                     = 'root',
   String  $config_file_group                     = 'root',
   Stdlib::Filemode $config_file_mode             = '0644',
+  Array[String] $configs                         = [],
   Hash[String, Hash] $receivers = {},
   Hash[String, Hash] $processors = {},
   Hash[String, Hash] $exporters = {},

--- a/spec/classes/otelcol_spec.rb
+++ b/spec/classes/otelcol_spec.rb
@@ -145,6 +145,17 @@ describe 'otelcol' do
         }
       end
 
+      context 'with configs' do
+        let :params do
+          {
+            configs: ['customconfig.yaml', 'env:MY_CONFIG_IN_AN_ENVVAR', 'https://server/config.yaml', '"yaml:exporters::debug::verbosity: normal"']
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('otelcol-environment').with_content(%r{--config=/etc/otelcol/config.yaml --config=customconfig.yaml --config=env:MY_CONFIG_IN_AN_ENVVAR --config=https://server/config.yaml --config="yaml:exporters::debug::verbosity: normal"}) }
+      end
+
       context 'with config_file owner' do
         let :params do
           {

--- a/templates/environment.conf.erb
+++ b/templates/environment.conf.erb
@@ -3,4 +3,4 @@
 
 # Command-line options for the <%= scope.lookupvar('otelcol::package_name')%>  service.
 # Run `/usr/bin/<%= scope.lookupvar('otelcol::package_name') %>  --help` to see all available options.
-OTELCOL_OPTIONS="<%= scope.lookupvar('otelcol::run_options')%> --config=<%= scope.lookupvar('otelcol::config_file')%>"
+OTELCOL_OPTIONS="<%= scope.lookupvar('otelcol::run_options')%> --config=<%= scope.lookupvar('otelcol::config_file') %><% unless scope.lookupvar('otelcol::configs').empty? -%> --config=<%= scope.lookupvar('otelcol::configs').join(' --config=') %><% end -%>"


### PR DESCRIPTION

#### Pull Request (PR) description
This feature adds a parameter `configs`which allows specifying additional config files or variables according to the [docs](https://opentelemetry.io/docs/collector/configuration/#location).
Unfortunately we cannot test whether this file, if specified, exists and the user is required to ensure this manually.
