### PR TITLE
telemetry: switch to using data structure list for telemetry

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -33,6 +33,11 @@
 ### Data types
 
 * [`Otelcol::Component::Name`](#Otelcol--Component--Name): Type for name of Otel Collector Ressources
+* [`Otelcol::Telemetry_exporter`](#Otelcol--Telemetry_exporter)
+* [`Otelcol::Telemetry_exporter::Periodic`](#Otelcol--Telemetry_exporter--Periodic)
+* [`Otelcol::Telemetry_exporter::Periodic::Otlp`](#Otelcol--Telemetry_exporter--Periodic--Otlp)
+* [`Otelcol::Telemetry_exporter::Pull`](#Otelcol--Telemetry_exporter--Pull)
+* [`Otelcol::Telemetry_exporter::Pull::Prometheus`](#Otelcol--Telemetry_exporter--Pull--Prometheus)
 
 ## Classes
 
@@ -62,8 +67,7 @@ The following parameters are available in the `otelcol` class:
 * [`extensions`](#-otelcol--extensions)
 * [`log_options`](#-otelcol--log_options)
 * [`metrics_level`](#-otelcol--metrics_level)
-* [`metrics_address_host`](#-otelcol--metrics_address_host)
-* [`metrics_address_port`](#-otelcol--metrics_address_port)
+* [`telemetry_exporters`](#-otelcol--telemetry_exporters)
 * [`service_ensure`](#-otelcol--service_ensure)
 * [`service_enable`](#-otelcol--service_enable)
 * [`manage_service`](#-otelcol--manage_service)
@@ -219,21 +223,13 @@ Level for metrics config
 
 Default value: `'basic'`
 
-##### <a name="-otelcol--metrics_address_host"></a>`metrics_address_host`
+##### <a name="-otelcol--telemetry_exporters"></a>`telemetry_exporters`
 
-Data type: `Optional[Stdlib::Host]`
+Data type: `Array[Otelcol::Telemetry_exporter]`
 
-Host metrics are listening to
+Hash for telemetry exporters config.  Currently support pull prometheus and periodic with otlp
 
-Default value: `undef`
-
-##### <a name="-otelcol--metrics_address_port"></a>`metrics_address_port`
-
-Data type: `Stdlib::Port`
-
-Port metrics are listening to
-
-Default value: `8888`
+Default value: `[{ 'prometheus' => { 'host' => '0.0.0.0', 'port' => 8888 } }]`
 
 ##### <a name="-otelcol--service_ensure"></a>`service_ensure`
 
@@ -582,4 +578,48 @@ Default value: `[]`
 Type for name of Otel Collector Ressources
 
 Alias of `Pattern[/\A[a-z0-9_-]+(\/[a-z0-9]+)?\z/]`
+
+### <a name="Otelcol--Telemetry_exporter"></a>`Otelcol::Telemetry_exporter`
+
+The Otelcol::Telemetry_exporter data type.
+
+Alias of `Variant[Struct[{ 'prometheus' => Otelcol::Telemetry_exporter::Pull }], Struct[{ 'otlp' => Otelcol::Telemetry_exporter::Periodic }]]`
+
+### <a name="Otelcol--Telemetry_exporter--Periodic"></a>`Otelcol::Telemetry_exporter::Periodic`
+
+The Otelcol::Telemetry_exporter::Periodic data type.
+
+Alias of `Variant[Otelcol::Telemetry_exporter::Periodic::Otlp]`
+
+### <a name="Otelcol--Telemetry_exporter--Periodic--Otlp"></a>`Otelcol::Telemetry_exporter::Periodic::Otlp`
+
+The Otelcol::Telemetry_exporter::Periodic::Otlp data type.
+
+Alias of
+
+```puppet
+Struct[{
+    endpoint => Stdlib::HTTPSUrl,
+    protocol => String
+}]
+```
+
+### <a name="Otelcol--Telemetry_exporter--Pull"></a>`Otelcol::Telemetry_exporter::Pull`
+
+The Otelcol::Telemetry_exporter::Pull data type.
+
+Alias of `Variant[Otelcol::Telemetry_exporter::Pull::Prometheus]`
+
+### <a name="Otelcol--Telemetry_exporter--Pull--Prometheus"></a>`Otelcol::Telemetry_exporter::Pull::Prometheus`
+
+The Otelcol::Telemetry_exporter::Pull::Prometheus data type.
+
+Alias of
+
+```puppet
+Struct[{
+    host => Stdlib::Host,
+    port => Stdlib::Port,
+}]
+```
 

--- a/examples/contrib_installation.pp
+++ b/examples/contrib_installation.pp
@@ -25,7 +25,7 @@ otelcol::receiver { 'prometheus' :
   pipelines => ['metrics'],
 }
 
-otelcol::exporter { 'logging':
+otelcol::exporter { 'debug':
   config    => { 'verbosity' => 'detailed' },
   pipelines => ['metrics'],
 }
@@ -36,7 +36,8 @@ otelcol::processor { 'batch':
 }
 
 class { 'otelcol':
-  manage_archive       => true,
-  package_name         => 'otelcol-contrib',
-  metrics_address_port => 8889,
+  manage_archive      => true,
+  package_name        => 'otelcol-contrib',
+  archive_version     => '0.132.4',
+  telemetry_exporters => [{ 'prometheus' => { 'host' => '0.0.0.0', 'port' => 8889 } }],
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,13 +6,23 @@ class otelcol::config inherits otelcol {
   assert_private()
   $proxy_host = $otelcol::proxy_host
   $proxy_port = $otelcol::proxy_port
+  $metrics_readers = $otelcol::telemetry_exporters.map |Hash $hash_element| {
+    $hash_element.map |String $name, Hash $value| {
+      $type = $value ? {
+        Otelcol::Telemetry_exporter::Pull     => 'pull',
+        Otelcol::Telemetry_exporter::Periodic => 'periodic',
+      }
+      $element = { $type => { 'exporter' => { $name => $value } } }
+      $element
+    }
+  }.flatten
   $component = {
     'service' => {
       'telemetry' => {
         'logs' => $otelcol::log_options,
         'metrics' => {
           'level' => $otelcol::metrics_level,
-          'address' => "${otelcol::metrics_address_host}:${otelcol::metrics_address_port}",
+          'readers' => $metrics_readers,
         },
       },
     },

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,10 +37,8 @@
 #   Hash for log_options config
 # @param metrics_level
 #   Level for metrics config
-# @param metrics_address_host
-#   Host metrics are listening to
-# @param metrics_address_port
-#   Port metrics are listening to
+# @param telemetry_exporters
+#   Hash for telemetry exporters config.  Currently support pull prometheus and periodic with otlp
 # @param service_ensure
 #   Ensure for service
 # @param service_enable
@@ -74,8 +72,7 @@ class otelcol (
   Hash[String, Hash] $extensions = {},
   Variant[Hash,String[1]]    $log_options                            = {},
   Enum['none','basic','normal','detailed'] $metrics_level = 'basic',
-  Optional[Stdlib::Host] $metrics_address_host    = undef,
-  Stdlib::Port $metrics_address_port             = 8888,
+  Array[Otelcol::Telemetry_exporter] $telemetry_exporters = [{ 'prometheus' => { 'host' => '0.0.0.0', 'port' => 8888 } }],
   Stdlib::Ensure::Service $service_ensure       = 'running',
   Boolean $service_enable                        = true,
   Boolean $manage_service                        = true,

--- a/spec/classes/otelcol_spec.rb
+++ b/spec/classes/otelcol_spec.rb
@@ -306,7 +306,9 @@ describe 'otelcol' do
                 },
                 'metrics' => {
                   'level' => 'basic',
-                  'address' => ':8888',
+                  'readers' => [
+                    { 'pull' => { 'exporter' => { 'prometheus' => { 'host' => '0.0.0.0', 'port' => 8888 } } } },
+                  ],
                 },
               },
             }
@@ -321,8 +323,6 @@ describe 'otelcol' do
         let :params do
           {
             metrics_level: 'detailed',
-            metrics_address_host: '127.0.0.1',
-            metrics_address_port: 1234,
           }
         end
         let(:configcontent) do
@@ -332,7 +332,39 @@ describe 'otelcol' do
                 'logs' => {},
                 'metrics' => {
                   'level' => 'detailed',
-                  'address' => '127.0.0.1:1234',
+                  'readers' => [
+                    { 'pull' => { 'exporter' => { 'prometheus' => { 'host' => '0.0.0.0', 'port' => 8888 } } } },
+                  ],
+                },
+              },
+            }
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat__fragment('otelcol-config-baseconfig').with_content(configcontent.to_yaml) }
+      end
+
+      context 'with multiple telemetry config' do
+        let :params do
+          {
+            telemetry_exporters: [
+              { 'prometheus' => { 'host' => '0.0.0.0', 'port' => 8888 } },
+              { 'otlp' => { 'endpoint' => 'https://example.org', 'protocol' => 'http/protobuf' } }
+            ],
+          }
+        end
+        let(:configcontent) do
+          {
+            'service' => {
+              'telemetry' => {
+                'logs' => {},
+                'metrics' => {
+                  'level' => 'basic',
+                  'readers' => [
+                    { 'pull' => { 'exporter' => { 'prometheus' => { 'host' => '0.0.0.0', 'port' => 8888 } } } },
+                    { 'periodic' => { 'exporter' => { 'otlp' => { 'endpoint' => 'https://example.org', 'protocol' => 'http/protobuf' } } } },
+                  ],
                 },
               },
             }

--- a/types/telemetry_exporter.pp
+++ b/types/telemetry_exporter.pp
@@ -1,0 +1,4 @@
+type Otelcol::Telemetry_exporter = Variant[
+  Struct[{ 'prometheus' => Otelcol::Telemetry_exporter::Pull }],
+  Struct[{ 'otlp' => Otelcol::Telemetry_exporter::Periodic }],
+]

--- a/types/telemetry_exporter/periodic.pp
+++ b/types/telemetry_exporter/periodic.pp
@@ -1,0 +1,1 @@
+type Otelcol::Telemetry_exporter::Periodic = Variant[Otelcol::Telemetry_exporter::Periodic::Otlp]

--- a/types/telemetry_exporter/periodic/otlp.pp
+++ b/types/telemetry_exporter/periodic/otlp.pp
@@ -1,0 +1,4 @@
+type Otelcol::Telemetry_exporter::Periodic::Otlp = Struct[{
+    endpoint => Stdlib::HTTPSUrl,
+    protocol => String
+}]

--- a/types/telemetry_exporter/pull.pp
+++ b/types/telemetry_exporter/pull.pp
@@ -1,0 +1,1 @@
+type Otelcol::Telemetry_exporter::Pull = Variant[Otelcol::Telemetry_exporter::Pull::Prometheus]

--- a/types/telemetry_exporter/pull/prometheus.pp
+++ b/types/telemetry_exporter/pull/prometheus.pp
@@ -1,0 +1,4 @@
+type Otelcol::Telemetry_exporter::Pull::Prometheus = Struct[{
+    host => Stdlib::Host,
+    port => Stdlib::Port,
+}]


### PR DESCRIPTION
As of Collector v0.123.0, the service::telemetry::metrics::address
setting is ignored and in the most recent version causes an error

As such move to supporting structure telemetry paramaters