### PR TITLE
otelcol::config: Add proxy support

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -71,6 +71,8 @@ The following parameters are available in the `otelcol` class:
 * [`localpath_archive`](#-otelcol--localpath_archive)
 * [`archive_version`](#-otelcol--archive_version)
 * [`archive_location`](#-otelcol--archive_location)
+* [`proxy_host`](#-otelcol--proxy_host)
+* [`proxy_port`](#-otelcol--proxy_port)
 
 ##### <a name="-otelcol--package_name"></a>`package_name`
 
@@ -288,6 +290,22 @@ Data type: `String[1]`
 Path to archive without filetype extension
 
 Default value: `"https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${archive_version}/${package_name}_${archive_version}_linux_amd64"`
+
+##### <a name="-otelcol--proxy_host"></a>`proxy_host`
+
+Data type: `Optional[Stdlib::Host]`
+
+
+
+Default value: `undef`
+
+##### <a name="-otelcol--proxy_port"></a>`proxy_port`
+
+Data type: `Stdlib::Port`
+
+
+
+Default value: `8888`
 
 ### <a name="otelcol--config"></a>`otelcol::config`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,8 @@
 #
 class otelcol::config inherits otelcol {
   assert_private()
+  $proxy_host = $otelcol::proxy_host
+  $proxy_port = $otelcol::proxy_port
   $component = {
     'service' => {
       'telemetry' => {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,6 +84,8 @@ class otelcol (
   # Boolean $manage_user                           = false,
   String[1] $archive_version                     = '0.89.0',
   String[1] $archive_location          = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${archive_version}/${package_name}_${archive_version}_linux_amd64",
+  Optional[Stdlib::Host] $proxy_host = undef,
+  Stdlib::Port $proxy_port = 8888,
 ) {
   contain otelcol::install
   contain otelcol::config

--- a/spec/classes/otelcol_spec.rb
+++ b/spec/classes/otelcol_spec.rb
@@ -22,6 +22,7 @@ describe 'otelcol' do
           is_expected.to contain_concat__fragment('otelcol-config-baseconfig')
           is_expected.to contain_file('otelcol-environment').with_path('/etc/otelcol/otelcol.conf')
           is_expected.to contain_file('otelcol-environment').with_content(%r{--config=/etc/otelcol/config.yaml"})
+          is_expected.to contain_file('otelcol-environment').without_content(%r{HTTPS?_PROXY})
         }
 
         it {
@@ -351,6 +352,18 @@ describe 'otelcol' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_service('otelcol').with_ensure('stopped') }
+      end
+
+      context 'with proxy_host' do
+        let :params do
+          {
+            proxy_host: '127.0.0.1',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('otelcol-environment').with_content(%r{HTTP_PROXY="127.0.0.1:8888"}) }
+        it { is_expected.to contain_file('otelcol-environment').with_content(%r{HTTPS_PROXY="127.0.0.1:8888"}) }
       end
 
       context 'with service_configcheck' do

--- a/templates/environment.conf.erb
+++ b/templates/environment.conf.erb
@@ -4,3 +4,7 @@
 # Command-line options for the <%= scope.lookupvar('otelcol::package_name')%>  service.
 # Run `/usr/bin/<%= scope.lookupvar('otelcol::package_name') %>  --help` to see all available options.
 OTELCOL_OPTIONS="<%= scope.lookupvar('otelcol::run_options')%> --config=<%= scope.lookupvar('otelcol::config_file') %><% unless scope.lookupvar('otelcol::configs').empty? -%> --config=<%= scope.lookupvar('otelcol::configs').join(' --config=') %><% end -%>"
+<%- unless @proxy_host.nil? -%>
+HTTP_PROXY="<%= @proxy_host %>:<%= @proxy_port %>"
+HTTPS_PROXY="<%= @proxy_host %>:<%= @proxy_port %>"
+<%- end -%>


### PR DESCRIPTION
There are some situations that require to route exporters via a proxy. The opentelementry documentations suggests that any exorters that use net/http (which i assume is most) will support standard HTTP(s)_HOST.

This PR adds support to add theses variables to the systemd environment file
