### PR TITLE
init: drop metricts address and metrics port

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -62,8 +62,11 @@ The following parameters are available in the `otelcol` class:
 * [`extensions`](#-otelcol--extensions)
 * [`log_options`](#-otelcol--log_options)
 * [`metrics_level`](#-otelcol--metrics_level)
-* [`metrics_address_host`](#-otelcol--metrics_address_host)
-* [`metrics_address_port`](#-otelcol--metrics_address_port)
+* [`metrics_mode`](#-otelcol--metrics_mode)
+* [`metrics_prometheus_host`](#-otelcol--metrics_prometheus_host)
+* [`metrics_prometheus_port`](#-otelcol--metrics_prometheus_port)
+* [`metrics_otlp_endpoint`](#-otelcol--metrics_otlp_endpoint)
+* [`metrics_otlp_protocol`](#-otelcol--metrics_otlp_protocol)
 * [`service_ensure`](#-otelcol--service_ensure)
 * [`service_enable`](#-otelcol--service_enable)
 * [`manage_service`](#-otelcol--manage_service)
@@ -219,21 +222,45 @@ Level for metrics config
 
 Default value: `'basic'`
 
-##### <a name="-otelcol--metrics_address_host"></a>`metrics_address_host`
+##### <a name="-otelcol--metrics_mode"></a>`metrics_mode`
 
-Data type: `Optional[Stdlib::Host]`
+Data type: `Enum['pull','push']`
 
-Host metrics are listening to
+Mode for metrics config either pull or push
 
-Default value: `undef`
+Default value: `'pull'`
 
-##### <a name="-otelcol--metrics_address_port"></a>`metrics_address_port`
+##### <a name="-otelcol--metrics_prometheus_host"></a>`metrics_prometheus_host`
+
+Data type: `Stdlib::Host`
+
+Host for internal telemetry Prometheus metrics
+
+Default value: `'0.0.0.0'`
+
+##### <a name="-otelcol--metrics_prometheus_port"></a>`metrics_prometheus_port`
 
 Data type: `Stdlib::Port`
 
-Port metrics are listening to
+Port for internal telemetry Prometheus metrics
 
 Default value: `8888`
+
+##### <a name="-otelcol--metrics_otlp_endpoint"></a>`metrics_otlp_endpoint`
+
+Data type: `Stdlib::HTTPSUrl`
+
+OTLP endpoint for internal telemetry metrics
+
+Default value: `'https://backend:4318'`
+
+##### <a name="-otelcol--metrics_otlp_protocol"></a>`metrics_otlp_protocol`
+
+Data type: `String[1]`
+
+OTLP protocol for internal telemetry metrics
+
+Default value: `'http/protobuf'`
 
 ##### <a name="-otelcol--service_ensure"></a>`service_ensure`
 

--- a/examples/contrib_installation.pp
+++ b/examples/contrib_installation.pp
@@ -36,7 +36,6 @@ otelcol::processor { 'batch':
 }
 
 class { 'otelcol':
-  manage_archive       => true,
-  package_name         => 'otelcol-contrib',
-  metrics_address_port => 8889,
+  manage_archive => true,
+  package_name   => 'otelcol-contrib',
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,13 +6,35 @@ class otelcol::config inherits otelcol {
   assert_private()
   $proxy_host = $otelcol::proxy_host
   $proxy_port = $otelcol::proxy_port
+  $metrics_readers = $otelcol::metrics_mode ? {
+    'pull' => [
+      'pull'  => {
+        'exporter' => {
+          'prometheus' => {
+            'host' => $otelcol::metrics_prometheus_host,
+            'port' => $otelcol::metrics_prometheus_port,
+          },
+        },
+      },
+    ],
+    'push' => [
+      'periodic'  => {
+        'exporter' => {
+          'otlp' => {
+            'protocol' => $otelcol::metrics_otlp_protocol,
+            'endpoint' => $otelcol::metrics_otlp_endpoint,
+          },
+        },
+      },
+    ],
+  }
   $component = {
     'service' => {
       'telemetry' => {
         'logs' => $otelcol::log_options,
         'metrics' => {
           'level' => $otelcol::metrics_level,
-          'address' => "${otelcol::metrics_address_host}:${otelcol::metrics_address_port}",
+          'readers' => $otelcol::metrics_readers,
         },
       },
     },

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,10 +37,16 @@
 #   Hash for log_options config
 # @param metrics_level
 #   Level for metrics config
-# @param metrics_address_host
-#   Host metrics are listening to
-# @param metrics_address_port
-#   Port metrics are listening to
+# @param metrics_mode
+#   Mode for metrics config either pull or push
+# @param metrics_prometheus_host
+#   Host for internal telemetry Prometheus metrics
+# @param metrics_prometheus_port
+#   Port for internal telemetry Prometheus metrics
+# @param metrics_otlp_endpoint
+#   OTLP endpoint for internal telemetry metrics
+# @param metrics_otlp_protocol
+#   OTLP protocol for internal telemetry metrics
 # @param service_ensure
 #   Ensure for service
 # @param service_enable
@@ -73,9 +79,12 @@ class otelcol (
   Hash[String, Hash] $pipelines = {},
   Hash[String, Hash] $extensions = {},
   Variant[Hash,String[1]]    $log_options                            = {},
+  Enum['pull','push'] $metrics_mode = 'pull',
   Enum['none','basic','normal','detailed'] $metrics_level = 'basic',
-  Optional[Stdlib::Host] $metrics_address_host    = undef,
-  Stdlib::Port $metrics_address_port             = 8888,
+  Stdlib::Host $metrics_prometheus_host = '0.0.0.0',
+  Stdlib::Port $metrics_prometheus_port = 8888,
+  Stdlib::HTTPSUrl $metrics_otlp_endpoint = 'https://backend:4318',
+  String[1] $metrics_otlp_protocol = 'http/protobuf',
   Stdlib::Ensure::Service $service_ensure       = 'running',
   Boolean $service_enable                        = true,
   Boolean $manage_service                        = true,

--- a/spec/classes/otelcol_spec.rb
+++ b/spec/classes/otelcol_spec.rb
@@ -321,8 +321,6 @@ describe 'otelcol' do
         let :params do
           {
             metrics_level: 'detailed',
-            metrics_address_host: '127.0.0.1',
-            metrics_address_port: 1234,
           }
         end
         let(:configcontent) do
@@ -332,7 +330,6 @@ describe 'otelcol' do
                 'logs' => {},
                 'metrics' => {
                   'level' => 'detailed',
-                  'address' => '127.0.0.1:1234',
                 },
               },
             }


### PR DESCRIPTION
As of Collector v0.123.0, the service::telemetry::metrics::address setting is ignored and in the most recent version causes an error

As such create separate params for Prometheus and otel